### PR TITLE
Remove outdated/unsafe OpenSSL pin

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -113,7 +113,6 @@ dependencies:
   - ncurses=6.3
   - numpy=1.24.1
   - oauth2client=4.1.3
-  - openssl=3.0.7
   - packaging=23.0
   - pandas=1.5.3
   - paramiko=3.0.0


### PR DESCRIPTION
OpenSSL is always future compatible, and updates almost always have security patches. OpenSSL 3.0.7 has a few buffer overflow vulnerabilities, and so it isn't being served, and the environment cannot be solved.